### PR TITLE
fix: parse variants whose prefix looks like a region, script, or extlang

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -167,7 +167,7 @@ export function parse(tag, options = {}) {
         isAlphabetical(value.charCodeAt(index + 1)) &&
         isAlphabetical(value.charCodeAt(index + 2)) &&
         isAlphabetical(value.charCodeAt(index + 3)) &&
-        !isAlphabetical(value.charCodeAt(index + 4))
+        !isAlphanumerical(value.charCodeAt(index + 4))
       ) {
         if (groups > 2 /* Max extended language subtag count. */) {
           return fail(
@@ -192,7 +192,7 @@ export function parse(tag, options = {}) {
       isAlphabetical(value.charCodeAt(index + 2)) &&
       isAlphabetical(value.charCodeAt(index + 3)) &&
       isAlphabetical(value.charCodeAt(index + 4)) &&
-      !isAlphabetical(value.charCodeAt(index + 5))
+      !isAlphanumerical(value.charCodeAt(index + 5))
     ) {
       result.script = source.slice(index + 1, index + 5)
       index += 5
@@ -204,7 +204,7 @@ export function parse(tag, options = {}) {
       if (
         isAlphabetical(value.charCodeAt(index + 1)) &&
         isAlphabetical(value.charCodeAt(index + 2)) &&
-        !isAlphabetical(value.charCodeAt(index + 3))
+        !isAlphanumerical(value.charCodeAt(index + 3))
       ) {
         result.region = source.slice(index + 1, index + 3)
         index += 3
@@ -215,7 +215,7 @@ export function parse(tag, options = {}) {
         isDecimal(value.charCodeAt(index + 1)) &&
         isDecimal(value.charCodeAt(index + 2)) &&
         isDecimal(value.charCodeAt(index + 3)) &&
-        !isDecimal(value.charCodeAt(index + 4))
+        !isAlphanumerical(value.charCodeAt(index + 4))
       ) {
         result.region = source.slice(index + 1, index + 4)
         index += 4

--- a/test/parse.js
+++ b/test/parse.js
@@ -359,4 +359,42 @@ test('.parse()', async function (t) {
       'should return untill the error when `forgiving: true`'
     )
   })
+
+  await t.test('Variant directly after language', function () {
+    // RFC 5646 allows a variant subtag immediately after the language, with no
+    // script or region in between. A variant whose leading characters look like
+    // a shorter region/script/extlang (e.g. the registered Portuguese `ao1990`)
+    // must not be split.
+    assert.deepEqual(
+      parse('pt-ao1990'),
+      {
+        language: 'pt',
+        extendedLanguageSubtags: [],
+        script: null,
+        region: null,
+        variants: ['ao1990'],
+        extensions: [],
+        privateuse: [],
+        irregular: null,
+        regular: null
+      },
+      'should parse a `5*8alphanum` variant that starts like a region'
+    )
+
+    assert.deepEqual(
+      parse('en-123a'),
+      {
+        language: 'en',
+        extendedLanguageSubtags: [],
+        script: null,
+        region: null,
+        variants: ['123a'],
+        extensions: [],
+        privateuse: [],
+        irregular: null,
+        regular: null
+      },
+      'should parse a `DIGIT 3alphanum` variant that starts like a UN M49 region'
+    )
+  })
 })


### PR DESCRIPTION
RFC 5646 allows a variant subtag directly after the language (`langtag = language ["-" script] ["-" region] *("-" variant) ...` — script and region are optional). `parse()` rejects such tags when the variant's leading characters match a shorter fixed-length subtag:

```js
parse('pt-ao1990')  // language: null  (expected variant ['ao1990'])
parse('en-123a')    // language: null  (expected variant ['123a'])
parse('en-abcd1')   // language: null  (expected variant ['abcd1'])
```

`ao1990` is the **registered** Portuguese 1990-orthography variant, so `pt-ao1990` is a real, widely-used tag; `Intl.getCanonicalLocales('pt-ao1990')` returns `['pt-ao1990']`.

### Cause
Each of the four fixed-length subtag matchers in `lib/parse.js` (extlang `3ALPHA`, script `4ALPHA`, region `2ALPHA`, region `3DIGIT`) only checks that the character after the subtag is **not of the same character class** (`!isAlphabetical` / `!isDecimal`). A subtag is actually complete only when the next character is a boundary (`-` or end of input). When the next character is a *different-class* alphanumeric, the matcher treats it as a boundary and grabs a partial subtag, splitting a longer variant:

- `pt-ao1990` → `ao` taken as a 2-alpha region (next char `1` is not alphabetical), leaving `1990` as superfluous content.
- `en-123a` → `123` taken as a 3-digit region (next char `a` is not decimal).
- `en-abcd1` → `abcd` taken as a 4-alpha script (next char `1` is not alphabetical).

### Fix
Check that the character following a fixed-length subtag is not **alphanumeric** (`!isAlphanumerical`, already imported), i.e. that the subtag actually terminates at a `-`/end boundary. Four one-token changes.

### Tests
Added a `Variant directly after language` case (`pt-ao1990`, `en-123a`). It fails on the current code and passes with the fix. The full suite (incl. all fixtures and RFC 5646 Appendix A) stays green at 100% coverage; the reject-invalid contract is unchanged (`en-ab12`, `en-abc1`, `en--US`, `en-GB-abcdefghi` still rejected).
